### PR TITLE
Allow injection of crypto keys into the manager.

### DIFF
--- a/waddrmgr/address.go
+++ b/waddrmgr/address.go
@@ -25,7 +25,6 @@ import (
 	"github.com/conformal/btcec"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcutil/hdkeychain"
-	"github.com/conformal/btcwallet/snacl"
 )
 
 // zero sets all bytes in the passed slice to zero.  This is used to
@@ -139,7 +138,7 @@ var _ ManagedPubKeyAddress = (*managedAddress)(nil)
 // The returned clear text private key will always be a copy that may be safely
 // used by the caller without worrying about it being zeroed during an address
 // lock.
-func (a *managedAddress) unlock(key *snacl.CryptoKey) ([]byte, error) {
+func (a *managedAddress) unlock(key EncryptorDecryptor) ([]byte, error) {
 	// Protect concurrent access to clear text private key.
 	a.privKeyMutex.Lock()
 	defer a.privKeyMutex.Unlock()
@@ -402,7 +401,7 @@ var _ ManagedScriptAddress = (*scriptAddress)(nil)
 // invalid or the encrypted script is not available.  The returned clear text
 // script will always be a copy that may be safely used by the caller without
 // worrying about it being zeroed during an address lock.
-func (a *scriptAddress) unlock(key *snacl.CryptoKey) ([]byte, error) {
+func (a *scriptAddress) unlock(key EncryptorDecryptor) ([]byte, error) {
 	// Protect concurrent access to clear text script.
 	a.scriptMutex.Lock()
 	defer a.scriptMutex.Unlock()


### PR DESCRIPTION
Useful to test error conditions.

Also provide a new function that wraps snacl.GenerateCryptoKey(),
defined as a variable so that it can be replaced in tests.
