### PR TITLE
Turn echo off when reading passwords

### DIFF
--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ type config struct {
 	Password         string   `short:"P" long:"password" default-mask:"-" description:"Password for client and btcd authorization"`
 	BtcdUsername     string   `long:"btcdusername" description:"Alternative username for btcd authorization"`
 	BtcdPassword     string   `long:"btcdpassword" default-mask:"-" description:"Alternative password for btcd authorization"`
-	WalletPass       string   `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
+	WalletPass       []byte   `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
 	RPCCert          string   `long:"rpccert" description:"File containing the certificate file"`
 	RPCKey           string   `long:"rpckey" description:"File containing the certificate key"`
 	RPCMaxClients    int64    `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`
@@ -244,7 +244,7 @@ func loadConfig() (*config, []string, error) {
 		ConfigFile:       defaultConfigFile,
 		DataDir:          defaultDataDir,
 		LogDir:           defaultLogDir,
-		WalletPass:       walletPubPassphrase,
+		WalletPass:       defaultPubPassphrase,
 		RPCKey:           defaultRPCKeyFile,
 		RPCCert:          defaultRPCCertFile,
 		DisallowFree:     defaultDisallowFree,

--- a/config.go
+++ b/config.go
@@ -68,7 +68,7 @@ type config struct {
 	Password         string   `short:"P" long:"password" default-mask:"-" description:"Password for client and btcd authorization"`
 	BtcdUsername     string   `long:"btcdusername" description:"Alternative username for btcd authorization"`
 	BtcdPassword     string   `long:"btcdpassword" default-mask:"-" description:"Alternative password for btcd authorization"`
-	WalletPass       []byte   `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
+	WalletPass       string   `long:"walletpass" default-mask:"-" description:"The public wallet password -- Only required if the wallet was created with one"`
 	RPCCert          string   `long:"rpccert" description:"File containing the certificate file"`
 	RPCKey           string   `long:"rpckey" description:"File containing the certificate key"`
 	RPCMaxClients    int64    `long:"rpcmaxclients" description:"Max number of RPC clients for standard connections"`

--- a/wallet.go
+++ b/wallet.go
@@ -50,7 +50,7 @@ var (
 // used when the user indicates they do not want additional protection
 // provided by having all public data in the wallet encrypted by a
 // passphrase only known to them.
-var defaultPubPassphrase = []byte("public")
+const defaultPubPassphrase = "public"
 
 // networkDir returns the directory name of a network directory to hold wallet
 // files.

--- a/wallet.go
+++ b/wallet.go
@@ -46,11 +46,11 @@ var (
 	ErrNotSynced = errors.New("wallet is not synchronized with the chain server")
 )
 
-// walletPubPassphrase is the default public wallet passphrase which is
+// defaultPubPassphrase is the default public wallet passphrase which is
 // used when the user indicates they do not want additional protection
 // provided by having all public data in the wallet encrypted by a
 // passphrase only known to them.
-var walletPubPassphrase = "public"
+var defaultPubPassphrase = []byte("public")
 
 // networkDir returns the directory name of a network directory to hold wallet
 // files.

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -169,7 +169,7 @@ func promptConsolePrivatePass(reader *bufio.Reader, legacyKeyStore *keystore.Sto
 // both.  Finally, all prompts are repeated until the user enters a valid
 // response.
 func promptConsolePublicPass(reader *bufio.Reader, privPass []byte, cfg *config) ([]byte, error) {
-	pubPass := defaultPubPassphrase
+	pubPass := []byte(defaultPubPassphrase)
 	usePubPass, err := promptConsoleListBool(reader, "Do you want "+
 		"to add an additional layer of encryption for public "+
 		"data?", "no")
@@ -181,7 +181,8 @@ func promptConsolePublicPass(reader *bufio.Reader, privPass []byte, cfg *config)
 		return pubPass, nil
 	}
 
-	if !bytes.Equal(cfg.WalletPass, pubPass) {
+	walletPass := []byte(cfg.WalletPass)
+	if !bytes.Equal(walletPass, pubPass) {
 		useExisting, err := promptConsoleListBool(reader, "Use the "+
 			"existing configured public passphrase for encryption "+
 			"of public data?", "no")
@@ -190,7 +191,7 @@ func promptConsolePublicPass(reader *bufio.Reader, privPass []byte, cfg *config)
 		}
 
 		if useExisting {
-			return cfg.WalletPass, nil
+			return walletPass, nil
 		}
 	}
 

--- a/walletsetup.go
+++ b/walletsetup.go
@@ -24,6 +24,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	"code.google.com/p/go.crypto/ssh/terminal"
+
 	"github.com/conformal/btcec"
 	"github.com/conformal/btcutil"
 	"github.com/conformal/btcutil/hdkeychain"
@@ -86,10 +88,12 @@ func promptConsolePass(reader *bufio.Reader, prefix string, confirm bool) (strin
 	prompt := fmt.Sprintf("%s: ", prefix)
 	for {
 		fmt.Print(prompt)
-		pass, err := reader.ReadString('\n')
+		passBytes, err := terminal.ReadPassword(0)
 		if err != nil {
 			return "", err
 		}
+		fmt.Print("\n")
+		pass := string(passBytes)
 		pass = strings.TrimSpace(pass)
 		if pass == "" {
 			continue
@@ -100,10 +104,12 @@ func promptConsolePass(reader *bufio.Reader, prefix string, confirm bool) (strin
 		}
 
 		fmt.Print("Confirm passphrase: ")
-		confirm, err := reader.ReadString('\n')
+		confirmBytes, err := terminal.ReadPassword(0)
 		if err != nil {
 			return "", err
 		}
+		fmt.Print("\n")
+		confirm := string(confirmBytes)
 		confirm = strings.TrimSpace(confirm)
 		if pass != confirm {
 			fmt.Println("The entered passphrases do not match")


### PR DESCRIPTION
Used the cross platform util  `ReadPassword` provided by `code.google.com/p/go.crypto/ssh/terminal` for this.
